### PR TITLE
Fix null pointer exception in lazy-container when view port changes

### DIFF
--- a/addon/views/lazy-container.js
+++ b/addon/views/lazy-container.js
@@ -62,7 +62,9 @@ StyleBindingsMixin, {
     var childViews = this.get('childViews');
     var content = this.get('content') || [];
     var clength = content.get('length');
-    var numShownViews = Math.min(this.get('length'), clength);
+    // this.get('length') does not always equal to childView.get('length')
+    // as length is not cacheable while childViews is cacheable
+    var numShownViews = Math.min(childViews.get('length'), clength);
     var startIndex = this.get('startIndex');
     // this is a necessary check otherwise we are trying to access an object
     // that doesn't exist
@@ -82,7 +84,7 @@ StyleBindingsMixin, {
       var itemIndex = startIndex + i;
       childView = childViews.objectAt(itemIndex % numShownViews);
       var item = content.objectAt(itemIndex);
-      if (item !== childView.get('content')) {
+      if (childView && item !== childView.get('content')) {
         childView.teardownContent();
         childView.set('itemIndex', itemIndex);
         childView.set('content', item);


### PR DESCRIPTION
Found a null pointer exception while using ember table.
This issue has been resolved without deep investigation in https://github.com/Addepar/ember-table/commit/fa6712392aa935110c731d5ca16c718992a0513f

1. 'length' is a computed property without cache, and it is computed from _childViews. And 'childViews' is a computed property with cache, and it is also computed from _childViews.

2. Sometimes when _childViews have some items which are 'preRender', childViews is not updated. Looks like childView will only be re-computed when 'inDOM' views changes in _childViews.

As illustrated in this screenshot, this.get('childViews') use cache and do not contain 'preRender' items in _childViews.
![4efe21e8-23c6-4c45-a2b0-d7e51e6b403f](https://cloud.githubusercontent.com/assets/13367570/10113767/d30aa3ec-639c-11e5-9e97-a1d87eef380b.png)

